### PR TITLE
fix: OG image showing path instead of title

### DIFF
--- a/lib/og/getPostFrontmatter.ts
+++ b/lib/og/getPostFrontmatter.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-const POST_CONTENT_PATH = "content/posts";
+const POST_CONTENT_PATH = path.join(process.cwd(), "content/posts");
 
 export interface PostFrontmatter {
 	title: string;


### PR DESCRIPTION
Fixes the OG image generation to show the article title instead of the URL path.

**Problem:** The OG image was displaying `ai-coding-security-infrastructure` instead of the article title.

**Root cause:** `POST_CONTENT_PATH` in `getPostFrontmatter.ts` was using a relative path (`content/posts`) without `process.cwd()`. In Next.js edge runtime (where OG images generate), this path resolution failed, returning null, which caused the fallback to use the slug.

**Fix:** Changed to `path.join(process.cwd(), "content/posts")` for proper absolute path resolution in all contexts.

After merge, the OG image cache will need to regenerate (happens automatically on next deploy).