### PR TITLE
fix: consolidate mobile padding so posts match homepage

### DIFF
--- a/app/posts/[slug]/page.module.css
+++ b/app/posts/[slug]/page.module.css
@@ -8,7 +8,6 @@
 	max-width: 690px;
 	margin: 0 auto;
 	width: 100%;
-	padding: 0 20px;
 	box-sizing: border-box;
 }
 

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -9,12 +9,12 @@
 	margin: 0 auto;
 	max-width: 690px;
 	flex: 1;
-	padding: 2rem;
+	padding: 0 1.5rem;
 }
 
 .main {
 	background: transparent;
-	padding: 2rem;
+	padding: 2rem 0;
 	flex: 1;
 	color: #fbf1f1;
 	position: relative;


### PR DESCRIPTION
## Summary

- Posts had ~84px horizontal padding per side on mobile from three nested layers (`.main` 2rem + `.content` 2rem + `.postLayout` 20px)
- Now `.content` owns all horizontal padding at 1.5rem (24px), matching the homepage grid margins
- Desktop layout unaffected — the post page breakout trick still works as before

## Test plan

- [ ] Check homepage on mobile (375px) — padding should be 24px per side
- [ ] Check a post page on mobile — padding should now also be 24px per side
- [ ] Check desktop layout on both pages — should be unchanged