### PR TITLE
fix: enable corepack on Vercel for pnpm 11

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
-	"buildCommand": "pnpm build",
-	"installCommand": "pnpm install --frozen-lockfile",
-	"framework": "nextjs",
-	"env": {
-		"ENABLE_EXPERIMENTAL_COREPACK": "1"
-	}
+	"framework": "nextjs"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"buildCommand": "pnpm build",
+	"installCommand": "pnpm install --frozen-lockfile",
+	"framework": "nextjs",
+	"env": {
+		"ENABLE_EXPERIMENTAL_COREPACK": "1"
+	}
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with `ENABLE_EXPERIMENTAL_COREPACK=1` so Vercel uses pnpm 11 from the `packageManager` field instead of falling back to pnpm 9.

Fixes the broken production build after the pnpm 11 upgrade.

## Test plan
- [ ] Vercel preview deploys successfully with pnpm 11