### PR TITLE
fix: remove COEP header blocking Giscus comments

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -54,10 +54,6 @@ const nextConfig = {
 						value: "same-origin",
 					},
 					{
-						key: "Cross-Origin-Embedder-Policy",
-						value: "credentialless",
-					},
-					{
 						key: "Reporting-Endpoints",
 						value: 'default="https://reports.akj.io"',
 					},


### PR DESCRIPTION
## Summary
- Removes the `Cross-Origin-Embedder-Policy: credentialless` header from `next.config.mjs`
- This header was blocking the Giscus iframe (`giscus.app refused to connect`) because giscus.app doesn't set `Cross-Origin-Resource-Policy` headers

## Test plan
- [ ] Verify Giscus comments load on any blog post (e.g. /pnpm-sbom)