### PR TITLE
fix: horizontal scroll from 100vw homeLayout

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -5,6 +5,7 @@
 	flex-direction: column;
 	/* Containing block for the document-height CSS-only ocean background. */
 	position: relative;
+	overflow-x: clip;
 }
 
 .content {


### PR DESCRIPTION
## Summary

- `100vw` includes the scrollbar width on desktop browsers, so the homeLayout breakout grid was ~15px wider than the visible area, causing horizontal scroll
- `overflow-x: clip` on the body element prevents the scroll without creating a new scroll container

One-line CSS fix.

## Test plan

- [ ] No horizontal scrollbar on desktop (any page)
- [ ] Home page layout still breaks out to full width correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended horizontal overflow, keeping page content within the visible layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->