### PR TITLE
refactor: replace 100vw breakout with CSS :has() opt-out

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -7,13 +7,6 @@
 		320px
 		minmax(2rem, 1fr);
 	align-items: start;
-	width: 100vw;
-	position: relative;
-	left: 50%;
-	right: 50%;
-	margin-left: -50vw;
-	margin-right: -50vw;
-	box-sizing: border-box;
 }
 
 .mainContent {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default async function FrontPage({ params }: PageProps) {
 
 	return (
 		<>
-			<div className={styles.homeLayout}>
+			<div className={styles.homeLayout} data-layout="full-width">
 				<article className={`${styles.mainContent} glassPanel`}>{page.Component()}</article>
 				<div className={`${styles.sidebar} glassPanel`}>
 					<RecentPosts limit={3} />

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -5,7 +5,6 @@
 	flex-direction: column;
 	/* Containing block for the document-height CSS-only ocean background. */
 	position: relative;
-	overflow-x: clip;
 }
 
 .content {
@@ -13,6 +12,11 @@
 	max-width: 690px;
 	flex: 1;
 	padding: 0 1.5rem;
+}
+
+.content:has([data-layout="full-width"]) {
+	max-width: none;
+	padding: 0;
 }
 
 .main {


### PR DESCRIPTION
## Summary

- Removes the `width: 100vw; left: 50%; margin-left: -50vw` breakout hack from `.homeLayout` that caused horizontal scroll (100vw includes scrollbar width)
- Removes the `overflow-x: clip` band-aid from PR #127
- The home page now signals `data-layout="full-width"` and `.content:has()` lifts its own `max-width` constraint
- The grid's `minmax(2rem, 1fr)` gutter columns handle their own edge padding

Net: -9 lines, +6 lines. No visual change.

## Test plan

- [x] No horizontal scrollbar on desktop (verified: 0px overflow)
- [x] Home page layout unchanged visually (verified screenshot)
- [x] Post pages still constrained to 690px (verified)
- [x] Mobile (375px) no overflow (verified: 0px overflow)
- [x] Build passes