### PR TITLE
fix(layout): widen content column from 690px to 760px

### DIFF
--- a/app/[slug]/_components/PostLayout.module.css
+++ b/app/[slug]/_components/PostLayout.module.css
@@ -1,5 +1,5 @@
 .postLayout {
-	max-width: 690px;
+	max-width: 760px;
 	margin: 0 auto;
 	width: 100%;
 	box-sizing: border-box;
@@ -36,11 +36,11 @@
 @media (min-width: 1024px) {
 	.postLayout {
 		display: grid;
-		grid-template-columns: 690px 280px;
+		grid-template-columns: 760px 280px;
 		grid-template-areas: "content toc";
 		gap: 3rem;
 		max-width: none;
-		width: calc(690px + 280px + 3rem);
+		width: calc(760px + 280px + 3rem);
 		margin-inline: calc((-280px - 3rem) / 2);
 	}
 

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -2,7 +2,7 @@
 	display: grid;
 	grid-template-columns:
 		minmax(2rem, 1fr)
-		minmax(auto, calc(1000px - 320px - 2rem))
+		minmax(auto, calc(1100px - 320px - 2rem))
 		2rem
 		320px
 		minmax(2rem, 1fr);
@@ -24,7 +24,7 @@
 
 @media (max-width: 1024px) {
 	.homeLayout {
-		grid-template-columns: minmax(2rem, 1fr) minmax(auto, 690px) minmax(2rem, 1fr);
+		grid-template-columns: minmax(2rem, 1fr) minmax(auto, 760px) minmax(2rem, 1fr);
 		grid-template-rows: auto auto;
 	}
 
@@ -42,7 +42,7 @@
 
 @media (max-width: 768px) {
 	.homeLayout {
-		grid-template-columns: minmax(1.5rem, 1fr) minmax(auto, 690px) minmax(
+		grid-template-columns: minmax(1.5rem, 1fr) minmax(auto, 760px) minmax(
 				1.5rem,
 				1fr
 			);

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -9,7 +9,7 @@
 
 .content {
 	margin: 0 auto;
-	max-width: 690px;
+	max-width: 760px;
 	flex: 1;
 	padding: 0 1.5rem;
 }

--- a/styles/global-styles.css
+++ b/styles/global-styles.css
@@ -107,7 +107,7 @@ h2 {
 
 .content {
 	margin: 0 auto;
-	max-width: 690px;
+	max-width: 760px;
 	width: 100%;
 	flex: 1;
 	padding: 0 20px;

--- a/styles/syntaxhighlighting.css
+++ b/styles/syntaxhighlighting.css
@@ -23,6 +23,25 @@ figure[data-rehype-pretty-code-figure] {
 	overflow: auto;
 	tab-size: 2;
 	font-size: 0.875rem;
+	scrollbar-width: thin;
+	scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+}
+
+figure[data-rehype-pretty-code-figure]::-webkit-scrollbar {
+	height: 6px;
+}
+
+figure[data-rehype-pretty-code-figure]::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+figure[data-rehype-pretty-code-figure]::-webkit-scrollbar-thumb {
+	background: rgba(255, 255, 255, 0.15);
+	border-radius: 3px;
+}
+
+figure[data-rehype-pretty-code-figure]::-webkit-scrollbar-thumb:hover {
+	background: rgba(255, 255, 255, 0.3);
 }
 
 code[data-line-numbers] {


### PR DESCRIPTION
## Summary

- Bumps the content column max-width from 690px to 760px across all pages
- More room for code blocks and text on wide screens without hurting readability (~82 chars/line)
- Home page grid adjusted to match

## Test plan

- [x] Post pages wider on desktop
- [x] Home page wider on desktop
- [x] Mobile layout unchanged
- [x] Build passes